### PR TITLE
Create date-order-powershell-script.ps1

### DIFF
--- a/date-order-powershell-script.ps1
+++ b/date-order-powershell-script.ps1
@@ -1,0 +1,22 @@
+$date = Get-Date
+$path = ($pwd).path
+
+$location = Get-ChildItem -Path $path | Sort-Object
+foreach ($file in $location)
+{
+
+    $file.CreationTime = $date
+    $file.LastAccessTime = $date
+    $file.LastWriteTime = $date
+    $date = $date.AddMinutes(1)
+    
+    '=' * 20
+    $CurrentFileInfo = Get-Item -LiteralPath $file.FullName
+    $CurrentFileInfo.FullName
+    $CurrentFileInfo.CreationTime
+    $CurrentFileInfo.LastWriteTime
+    $CurrentFileInfo.LastAccessTime 
+}
+$location
+
+Read-Host -Prompt "Press Enter to exit"


### PR DESCRIPTION
Adding a simple script that loops through and sets file date in alphabetical order.

I wrote this to make files display in the correct order on a device that would sort files by date only. Wasn't sure which date it went by, so I set all file dates the same.

The script starts on the current date, and increments by one minute per file.